### PR TITLE
Update foobar 2000 available plugins

### DIFF
--- a/source/manual/measures/nowplaying.html
+++ b/source/manual/measures/nowplaying.html
@@ -118,7 +118,7 @@ Measure=NowPlaying
 	Fully supported. Tested with AIMP 5.00.</li>
 
 	<li><b>foobar2000</b>: <code>PlayerName=CAD</code><br>
-	Fully supported. The <a href="https://github.com/RangerCD/foo-cad-plus/releases/">foo_cad plugin (download)</a> needs to be installed.</li>
+	Fully supported. Either the <a href="https://github.com/RangerCD/foo-cad-plus/releases/">foo_cad plugin (download)</a> or <a href="https://github.com/ghDaYuYu/foo_cad_nowplaying/releases/">CAD NowPlaying</a> needs to be installed.</li>
 
 	<li><b>iTunes</b>: <code>PlayerName=iTunes</code><br>
 	Fully supported. Tested with iTunes 10.2.</li>


### PR DESCRIPTION
CAD NowPlaying. It includes pull request from NighthawkSLO (to the original foo_cad plugin) and features fb2k API calls for local cover album art retrieval.